### PR TITLE
API Bump to ALPHA9 + ALPHA10

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: PlayerVaults
 main: PlayerVaults\PlayerVaults
-api: [2.0.0, 3.0.0, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5, 3.0.0-ALPHA6, 3.0.0-ALPHA7, 3.0.0-ALPHA8]
+api: [3.0.0-ALPHA7, 3.0.0-ALPHA8, 3.0.0-ALPHA9, 3.0.0-ALPHA10]
 version: 2.0
 commands:
   playervault:


### PR DESCRIPTION
* Getting rid of incompatible APIs.
* Adding 3.0.0-ALPHA9 and 3.0.0-ALPHA10 as they are the newest tagged releases for PMMP.