### PR TITLE
Fix #40

### DIFF
--- a/src/PlayerVaults/Task/FetchInventoryTask.php
+++ b/src/PlayerVaults/Task/FetchInventoryTask.php
@@ -99,7 +99,7 @@ class FetchInventoryTask extends AsyncTask {
                 $mysql->close();
                 break;
         }
-        if($data !== null){
+        if(!empty($data)){
             $nbt = new NetworkLittleEndianNBTStream();
             $nbt->readCompressed($data);
             $nbt = $nbt->getData();


### PR DESCRIPTION
Even after commit https://github.com/Muqsit/PlayerVaults/commit/024ced359e0dbe2dc7b9e2b4adc99f30b77f56c7, I still kept getting the error in Issue #40. Turns out https://github.com/Muqsit/PlayerVaults/blob/master/src/PlayerVaults/Task/FetchInventoryTask.php#L102 was checking if an empty array was null.

Fix has been tested and it works.